### PR TITLE
Facebook hook

### DIFF
--- a/hooks/config.json
+++ b/hooks/config.json
@@ -12,5 +12,12 @@
       "token": "",
       "room": ""
     }
+  },
+  {
+    "service": "facebook",
+    "options": {
+      "page_id" : "",
+      "page_access_token" : ""
+    }
   }]
 }

--- a/hooks/facebook.js
+++ b/hooks/facebook.js
@@ -1,0 +1,28 @@
+var humanize = require('humanize'),
+    request = require('request'),
+    fs = require('fs'),
+    path = require('path');
+
+var Facebook = function (options) {
+
+  var uploadUrl = 'https://graph-video.facebook.com/' + options.page_id + '/videos?access_token=' + options.page_access_token;
+
+  return function (data, cb) {
+
+    console.log(humanize.date('Y-m-d H:i:s')+' Posting on facebook: ', data.text, data.thumbnail);
+
+    var r = request.post(uploadUrl, function (err, httpResponse, body) {
+      if (err){
+        console.error(humanize.date('Y-m-d H:i:s')+' Error while posting on facebook: ', e);
+      }
+      cb(err);
+    });
+
+    var form = r.form();
+    form.append('description', data.text + ' ' + data.video);
+    form.append('title', data.text.split('#WorldCup')[0]);
+    form.append('source', fs.createReadStream(path.join(__dirname, '..', data.videofilename)));
+  }
+};
+
+module.exports = Facebook;

--- a/hooks/index.js
+++ b/hooks/index.js
@@ -14,8 +14,9 @@ if(fs.existsSync(configFile)) {
 
 var services = {
   hipchat: require('./hipchat'),
-  slack: require('./slack')
-}
+  slack: require('./slack'),
+  facebook: require('./facebook')
+};
 
 module.exports = function(data, cb) {
   var cb = cb || function() {};

--- a/server.js
+++ b/server.js
@@ -113,6 +113,7 @@ server.get('/record', mw.localhost, function(req, res) {
             id: videoId 
           , text: text 
           , video: videoUrl
+          , videofilename: videofilename
           , thumbnail: videoUrl.replace('video','thumbnail')
           , gif: settings.base_url+"/videos/"+videoId+".gif" 
           , gifsize: fs.statSync('videos/'+videoId+'.gif').size

--- a/test/hooks.spec.js
+++ b/test/hooks.spec.js
@@ -4,6 +4,7 @@ var hooks = require('../hooks/index')
 var data = { id: '2014-06-19-20-31-24',
   text: 'Goal for Belgium! #URU 1-1 #ENG #WorldCup \n📺Video:',
   video: 'http://replaylastgoal.com/video?v=2014-06-19-20-31-24',
+  videofilename: 'test/videos/test.mp4',
   thumbnail: 'http://replaylastgoal.com/thumbnail?v=2014-06-19-20-31-24',
   gif: 'http://replaylastgoal.com/videos/2014-06-19-20-31-24.gif',
   gifsize: 2499245 };  


### PR DESCRIPTION
Plain implementation of the facebook hook.
Posts a link to the page on a facebook page. The video cannot be played from the feed (yet?)

Configuration must include a "page access token", ideally a long-lived one (2 months validity) which is a real PITA to obtain. (I have one which is valid for the 'replaylastgoal' facebook page, I'll send it to you for deployment). Maybe next step would be to include an admin page that helps with generating the token?
