### PR TITLE
Improve gif quality by appropriately sizing gifs

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -148,12 +148,12 @@ var utils = {
   mp4toGIF: function(mp4file, start, duration, cb) {
     cb = cb || function() {};
 
-    // ffmpeg -y -ss 0 -t 20 -i 2014-06-18-16-20-06.mp4 -t 14 -s qvga -r 8 out/anim.gif
+    // ffmpeg -y -ss 0 -i 2014-06-18-16-20-06.mp4 -t 14 -vf scale=520:-1 -r 7 out/anim.gif
     var outputfilename = mp4file.replace('.mp4','.gif');
     var params = ['-y','-ss',start,'-t',duration,'-i',mp4file];
 
-    params.push('-s');
-    params.push('qvga');
+    params.push('-vf');
+    params.push('scale=520:-1');
     params.push('-r');
     params.push('7');
 
@@ -168,7 +168,7 @@ var utils = {
     stream.on('error', logerror);
     stream.on('exit', function(e) {
       console.log(outputfilename+ " created - optimizing the animated gif with gifsicle...");
-      var stream2 = spawn('gifsicle', ['-O3',outputfilename,'-o',outputfilename]);
+      var stream2 = spawn('gifsicle', ['-O3','--colors','256','-b',outputfilename]);
       stream2.on('error', logerror);
       stream2.on('exit', function(e) {
         cb(null, outputfilename);


### PR DESCRIPTION
The existing code resized gifs down to 320x240 which twitter then scaled back up to 528x396 resulting in grainy gifs. This change r
It also tells gifsicle to limit gif colors to 256 which should reduce file size.

NOTE: This code should be tested to ensure that it generates gifs below the 3MB Twitter limit.
