### PR TITLE
Some Slack improvement & fix in settings.json

### DIFF
--- a/hooks/config.json
+++ b/hooks/config.json
@@ -2,7 +2,9 @@
   "hooks": [{
     "service": "slack",
     "options": {
-      "webhookurl": ""
+      "webhookurl": "",
+      "channel": "",
+      "username": ""
     }
   },
   {

--- a/hooks/slack.js
+++ b/hooks/slack.js
@@ -18,10 +18,11 @@ var Slack = function(options) {
     }
 
     slack.send({
-      channel: options.channel || "#general", 
+      channel: options.channel || "#general",
       icon_url: 'http://i.imgur.com/4gkmsLq.png',
       text: text+" "+data.gif,
       username: options.username || "ReplayLastGoal",
+      unfurl_links: true,
       fields: fields
     }, cb);
   };

--- a/hooks/slack.js
+++ b/hooks/slack.js
@@ -19,7 +19,7 @@ var Slack = function(options) {
 
     slack.send({
       channel: options.channel || "#general", 
-      icon_url: 'http://replaylastgoal.com/img/avatar.png',
+      icon_url: 'http://i.imgur.com/4gkmsLq.png',
       text: text+" "+data.gif,
       username: options.username || "ReplayLastGoal",
       fields: fields

--- a/server.js
+++ b/server.js
@@ -20,7 +20,7 @@ var hooks = require('./hooks/index');
 var settings = require('./settings.'+env+'.json');
 
 var server = express();
-var port = process.env.PORT || process.env.NODE_PORT || 1212;
+var port = settings.port || 1212;
 server.set('port', port);
 
 server.recordingWindow = { start: -8, duration: 20 };
@@ -77,10 +77,10 @@ server.get('/record', mw.restricted, function(req, res) {
 
   if(((new Date).getTime() - server.lastRecording.time) < 5000) {
     console.error("Last recording less than 5s ago, aborting");
-    return res.send("Last recording less than 5s ago, aborting"); 
+    return res.send("Last recording less than 5s ago, aborting");
   }
 
-  var channel = req.param('channel', settings.channel); 
+  var channel = req.param('channel', settings.channel);
   var start = req.param('start', server.recordingWindow.start);
   var duration = req.param('duration', server.recordingWindow.duration);
   var text = req.param('text','');
@@ -99,23 +99,23 @@ server.get('/record', mw.restricted, function(req, res) {
     // Generating the thumbnail and animated gif
     async.parallel([
       function(done) {
-        utils.mp4toJPG(videofilename, Math.floor(duration/2), done); 
+        utils.mp4toJPG(videofilename, Math.floor(duration/2), done);
       },
       function(done) {
-        utils.mp4toGIF(videofilename, Math.max(2,start), Math.min(13,duration), done); 
+        utils.mp4toGIF(videofilename, Math.max(2,start), Math.min(13,duration), done);
       }], function(err, results) {
         server.busy = false;
         var data = {
-            id: videoId 
-          , text: text 
+            id: videoId
+          , text: text
           , video: videoUrl
           , videofilename: videofilename
           , thumbnail: videoUrl.replace('video','thumbnail')
-          , gif: settings.base_url+"/videos/"+videoId+".gif" 
+          , gif: settings.base_url+"/videos/"+videoId+".gif"
           , gifsize: fs.statSync('videos/'+videoId+'.gif').size
         }
         server.lastRecording.data = data;
-        try { 
+        try {
           hooks(data);
         } catch(e) {
           console.error("Error in hooks: ", e, e.stack);
@@ -155,7 +155,7 @@ server.get('/gif', mw.requireValidVideoID, function(req, res, next) {
 server.get('/live', mw.restricted, function(req, res) {
   var channel = req.param('channel', settings.channel);
   res.render('live.hbs', {
-    videostream: "/buffer/"+channel+"/livestream.m3u8" // settings.videostreams[channel] 
+    videostream: "/buffer/"+channel+"/livestream.m3u8" // settings.videostreams[channel]
   });
 });
 

--- a/settings.json
+++ b/settings.json
@@ -5,8 +5,8 @@
   "hipchat": {
     "auth_token": ""
   },
-  "videostreams" : { "channel1": "m3u8-url", "channel2": "m3u8-url" }
-  "channel": "channel1",
+  "videostreams" : { "ned1": "m3u8-url", "ned2": "m3u8-url" },
+  "channel": "ned1",
   "twitter": {
     "consumer_key": "",
     "consumer_secret": "",


### PR DESCRIPTION
I've updated Slack hook for a better integration & configuration.

Also, I've added a comma after `videostreams` in `settings.json`, because the json was invalid.
And I've renamed `channel*` in `ned*` to avoid an undefined error when spawing ffmpeg.

One things I'm not sure is about the `settings.port` in `server.js`. From my POV, if we defined a port in the configuration, it should be used in the server and not relying on the global configuration (ie: `process.env.*`). But me let me know if I should remove it from my PR.

Also, I've no idea how to run the test suite..
